### PR TITLE
Mention pk_regex in docs when using non-int pk

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -35,6 +35,9 @@ the performance hit of retrieving child models.
 This can be controlled by setting the ``polymorphic_list`` property on the
 parent admin.  Setting it to True will provide child models to the list template.
 
+Note: If you are using non-integer primary keys in your model, you have to edit ``pk_regex``, 
+for example ``pk_regex = '([\w-]+)'`` if you use UUIDs. Otherwise you cannot change model entries.
+
 The child models
 ----------------
 


### PR DESCRIPTION
I stumbled upon this and figured it out by checking the issue tracker. It should be mentioned in the docs that non-int pks require additional work to work properly.
